### PR TITLE
Added handling of strings in STR() too

### DIFF
--- a/core/my_basic.c
+++ b/core/my_basic.c
@@ -17769,6 +17769,13 @@ static int _std_str(mb_interpreter_t* s, void** l) {
 #endif /* MB_MANUAL_REAL_FORMATTING */
 
 		break;
+	case MB_DT_STRING:
+		lbuf = strlen(arg.value.string) + 1; /* Buffer needs to be as big as the string */
+		_RESIZE_CHAR_BUF(buf, lbuf);
+		char* str = mb_memdup(arg.value.string, lbuf); /* Create a copy of the string */
+		_CHAR_BUF_PTR(buf) = str;
+
+		break;
 	case MB_DT_TYPE: {
 			const char* sp = mb_get_type_string(arg.value.type);
 			char* ret = mb_strdup(sp, strlen(sp) + 1);


### PR DESCRIPTION
I figured that when iterating over values of different types (I implemented a fake PEEK/POKE) that it would be nice if STR() would also handle strings, even though that technically might not make sense. In this case, the string would just "fall through".