### PR TITLE
Fixed incorrect operator precedence

### DIFF
--- a/core/my_basic.c
+++ b/core/my_basic.c
@@ -1049,7 +1049,7 @@ static _object_t* _exp_assign = 0;
 	do { \
 		_instruct_common(__tuple) \
 		if(opndv1.type == _DT_INT && opndv2.type == _DT_INT) { \
-			if((real_t)(opndv1.data.integer __optr opndv2.data.integer) == (real_t)opndv1.data.integer __optr (real_t)opndv2.data.integer) { \
+			if((real_t)(opndv1.data.integer __optr opndv2.data.integer) == ((real_t)opndv1.data.integer __optr (real_t)opndv2.data.integer)) { \
 				val->type = _DT_INT; \
 				val->data.integer = opndv1.data.integer __optr opndv2.data.integer; \
 			} else { \


### PR DESCRIPTION
Before this commit, if `__optr` is `==` or `!=`, the if condition on line 1052 is unintendedly interpreted as
``` C
((real_t)(opndv1.data.integer __optr opndv2.data.integer) == (real_t)opndv1.data.integer)
    __optr
(real_t)opndv2.data.integer
```
because the associativity of `!=` and `==` operators in C is left-to-right. Fixed by fully parenthesize the complex comparison expression.