### PR TITLE
Fixed a bug where a && was used but should have been a ||

### DIFF
--- a/core/my_basic.c
+++ b/core/my_basic.c
@@ -3383,7 +3383,7 @@ static int mb_uu_getbom(const char** ch) {
 	char** ptr = (char**)ch;
 #endif /* __cplusplus */
 
-	if(!ptr && !(*ptr))
+	if(!ptr || !(*ptr))
 		return 0;
 
 	if((*ptr)[0] == -17 && (*ptr)[1] == -69 && (*ptr)[2] == -65) {


### PR DESCRIPTION
A small bug was found in the guard check for the mb_uu_getbom() function.  An AND was used when it should have been an OR.
